### PR TITLE
Improve logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,34 +5,30 @@ const fs = require('fs');
 
 app.use(express.static("./public"));
 
-let errorsWhileGettingData;
-
 const fetchData = async () => {
-
-  errorsWhileGettingData ?? null;
-
-  try {
-    const response = await axios.get("https://diablo2.io/dclone_api.php?", {
-      params: {
-        sk: "r",
-      },
-    });
-    allRegions = response.data;
-    // Faking response for testing purposes:
-    // allRegions[0].reporter_id = 333
-    // allRegions[0].progress = 5
-    // allRegions[10].progress = 9
-    return allRegions;
-  } catch (error) {
-    errorsWhileGettingData = error;
-  }
-
+  const response = await axios.get("https://diablo2.io/dclone_api.php?", {
+    params: {
+      sk: "r",
+    },
+  });
+  allRegions = response.data;
+  // Faking response for testing purposes:
+  // allRegions[0].reporter_id = 333
+  // allRegions[0].progress = 5
+  // allRegions[10].progress = 9
+  return allRegions;
 };
 
 let currentData = null;
 async function collectDataOnceInAMinute() {
-  dataForLogging = await fetchData();
-  currentData = dataForLogging;
+  let dataForLogging;
+
+  try {
+    dataForLogging = await fetchData();
+    currentData = dataForLogging;
+  } catch (error) {
+    dataForLogging = error;
+  }
   createLogs(dataForLogging);
   setTimeout(() => {
     collectDataOnceInAMinute();
@@ -58,9 +54,7 @@ const createLogs = (dataForLogging) => {
     }
   };
 
-  const isThereAnError = errorsWhileGettingData ? errorsWhileGettingData : dataForLogging;
-
-  lineToInsert = isNewLine() + JSON.stringify(isThereAnError);
+  lineToInsert = isNewLine() + JSON.stringify(dataForLogging);
 
   const newLine = () => fs.appendFile(pathToLogs, lineToInsert, (err) => {
     if (err) throw new Error('Something went wrong with the logging');

--- a/index.js
+++ b/index.js
@@ -5,18 +5,28 @@ const fs = require('fs');
 
 app.use(express.static("./public"));
 
+let errorsWhileGettingData;
+
 const fetchData = async () => {
-  const response = await axios.get("https://diablo2.io/dclone_api.php?", {
-    params: {
-      sk: "r",
-    },
-  });
-  allRegions = response.data;
-  // Faking response for testing purposes:
-  // allRegions[0].reporter_id = 333
-  // allRegions[0].progress = 5
-  // allRegions[10].progress = 9
-  return allRegions;
+
+  errorsWhileGettingData ?? null;
+
+  try {
+    const response = await axios.get("https://diablo2.io/dclone_api.php?", {
+      params: {
+        sk: "r",
+      },
+    });
+    allRegions = response.data;
+    // Faking response for testing purposes:
+    // allRegions[0].reporter_id = 333
+    // allRegions[0].progress = 5
+    // allRegions[10].progress = 9
+    return allRegions;
+  } catch (error) {
+    errorsWhileGettingData = error;
+  }
+
 };
 
 let currentData = null;
@@ -48,7 +58,9 @@ const createLogs = (dataForLogging) => {
     }
   };
 
-  lineToInsert = isNewLine() + JSON.stringify(dataForLogging);
+  const isThereAnError = errorsWhileGettingData ? errorsWhileGettingData : dataForLogging;
+
+  lineToInsert = isNewLine() + JSON.stringify(isThereAnError);
 
   const newLine = () => fs.appendFile(pathToLogs, lineToInsert, (err) => {
     if (err) throw new Error('Something went wrong with the logging');


### PR DESCRIPTION
I deliberately decided not to add any additional rules regarding catching errors: if an error is caught, we just put it into the logs and keep executing the "get" function every 30 seconds, as if there was no error at all.
The reason for that is that I'm not certain that the error won't go in, say, a week, if we just keep trying to get data from the API. It probably won't, but I think I shouldn't assume.